### PR TITLE
Allow setting of helm version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,11 +35,18 @@ inputs:
     description: If set true, disable to create pull request even if snapshots are changed
     required: false
 
+  helm_version:
+    description: The helm version to use
+    default: 'latest'
+    required: true
+
 runs:
   using: composite
   steps:
     - id: setup-helm
       uses: azure/setup-helm@v4
+      with:
+        version: ${{ inputs.helm_version }}
 
     - id: setup-chartsnap
       run: |


### PR DESCRIPTION
We're getting a lot of failures on CI with `chartsnap` due an issue with helm 3.18.0 (see https://github.com/helm/helm/issues/30880). We'd like to be able to pin to 3.17.3 temporarily until this issue is fixed - this updates the action to be able to take a `helm_version` to pin to.